### PR TITLE
2x speedup

### DIFF
--- a/scripts/t2v_model.py
+++ b/scripts/t2v_model.py
@@ -1462,7 +1462,6 @@ class GaussianDiffusion(object):
         del b
         del eps
         del x0
-        torch_gc()
         return xt_1
 
     @torch.no_grad()
@@ -1492,7 +1491,6 @@ class GaussianDiffusion(object):
                                      ddim_timesteps, eta)
             t.cpu()
             t = None
-            torch_gc()
             pbar.set_description(f"DDIM sampling {str(step)}")
         pbar.close()
         return xt


### PR DESCRIPTION
torch_gc() is very slow and is being called way to many times.

Here is a breakdown of the time taken inside of the ddim sample method
![image](https://user-images.githubusercontent.com/18043686/226454060-16cff63d-cebd-49e6-b83e-b794d41dd68a.png)
After removing the calls to torch_gc
![image](https://user-images.githubusercontent.com/18043686/226454284-15e748a0-38c1-4c0b-8598-b231b660f312.png)
We now spend most 99.8% of our time actually sampling instead of the previous 73%

I also remove a GC call inside the ddim_sample_loop method. With all of this combined, I go from ~1.3 it/s to ~2.6 it/s. I was not able to find any extra VRAM usage by removing these GC calls